### PR TITLE
fix == problem created by FORMULATEXT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.gitignore
+/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-.gitignore
-/.idea/

--- a/Text-Formula-Coverter.js
+++ b/Text-Formula-Coverter.js
@@ -7,7 +7,9 @@ function textToFunction() {
     for(var j = 0; j < values.length; j++){
       if(!range.getCell(j+1, i+1).isBlank()){
         values[j][i] = "=" + values[j][i];
-        values[j][i] = values[j][i].replace("==", "="); // Fixes problem created if text came from FORMULATEXT function.
+        if(left(values[j][i], 2) == "==" { // Test for == at beginning of formula. If present, fix it.
+          values[j][i] = right(values[j][i], len(values[j][i])-1);
+        }
       }
       
     }

--- a/Text-Formula-Coverter.js
+++ b/Text-Formula-Coverter.js
@@ -7,7 +7,7 @@ function textToFunction() {
     for(var j = 0; j < values.length; j++){
       if(!range.getCell(j+1, i+1).isBlank()){
         values[j][i] = "=" + values[j][i];
-        if(left(values[j][i], 2) == "==" { // Test for == at beginning of formula. If present, fix it.
+        if(left(values[j][i], 2) == "=="){ // Test for == at beginning of formula. If present, fix it.
           values[j][i] = right(values[j][i], len(values[j][i])-1);
         }
       }

--- a/Text-Formula-Coverter.js
+++ b/Text-Formula-Coverter.js
@@ -7,6 +7,7 @@ function textToFunction() {
     for(var j = 0; j < values.length; j++){
       if(!range.getCell(j+1, i+1).isBlank()){
         values[j][i] = "=" + values[j][i];
+        values[j][i] = values[j][i].replace("==", "="); // Fixes problem created if text came from FORMULATEXT function.
       }
       
     }

--- a/Text-Formula-Coverter.js
+++ b/Text-Formula-Coverter.js
@@ -7,8 +7,8 @@ function textToFunction() {
     for(var j = 0; j < values.length; j++){
       if(!range.getCell(j+1, i+1).isBlank()){
         values[j][i] = "=" + values[j][i];
-        if(left(values[j][i], 2) == "=="){ // Test for == at beginning of formula. If present, fix it.
-          values[j][i] = right(values[j][i], len(values[j][i])-1);
+        if( (values[j][i].substring(0,2)) == "=="){   // Test for == at beginning of formula. If present, fix it.
+          values[j][i] = values[j][i].substring(1,(values[j][i].length));
         }
       }
       


### PR DESCRIPTION
If the text to be converted to a formula was created by the FORMULATEXT function, it already starts with a =. Since textToFunction adds another = to the beginning of everything it converts, the formula will begin with == and create an error instead of a working formula.
Added a line to check for the presence of == after every conversion and replace it with =, if found.